### PR TITLE
Mirror repo structure in bucket

### DIFF
--- a/.github/workflows/deploy-gcs.yml
+++ b/.github/workflows/deploy-gcs.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   BUCKET: ${{ secrets.GCS_BUCKET }}
-  build_dir: dist  # cambialo si tu build sale en otra carpeta
+  SYNC_DIR: .  # carpeta del repo a sincronizar con el bucket
 
 jobs:
   deploy:
@@ -38,7 +38,7 @@ jobs:
         run: gsutil ls gs://${{ env.BUCKET }}/ || true
 
       - name: Upload to GCS (rsync)
-        run: gsutil -m rsync -r -d ./${{ env.build_dir }} gs://${{ env.BUCKET }}/visualizations/mapa-barrios/
+        run: gsutil -m rsync -r -d -x '(^|/)\.git/' ${{ env.SYNC_DIR }} gs://${{ env.BUCKET }}/
 
       - name: Set Cache-Control (optional)
-        run: gsutil -m setmeta -h "Cache-Control:public, max-age=300" gs://${{ env.BUCKET }}/visualizations/mapa-barrios/** || true
+        run: gsutil -m setmeta -h "Cache-Control:public, max-age=300" gs://${{ env.BUCKET }}/** || true


### PR DESCRIPTION
## Summary
- Sync entire repository to GCS bucket so structure matches GitHub
- Exclude `.git` directory during rsync

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: esbuild Permission denied)*
- `npm ci` *(fails: 403 Forbidden for leaflet package)*

------
https://chatgpt.com/codex/tasks/task_e_68975a7c2dd88320bd8699cbb7350e4d