### PR TITLE
Add Node build to GCS deploy workflow

### DIFF
--- a/.github/workflows/deploy-gcs.yml
+++ b/.github/workflows/deploy-gcs.yml
@@ -17,15 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      # Borrá esto si no necesitás build de Node
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: 18
+          cache: npm
       - run: npm ci
-        continue-on-error: true
       - run: npm run build
-        continue-on-error: true
 
       - name: Auth to Google Cloud (WIF)
         uses: google-github-actions/auth@v2
@@ -40,10 +37,7 @@ jobs:
         run: gsutil ls gs://${{ env.BUCKET }}/ || true
 
       - name: Upload to GCS (rsync)
-        run: gsutil -m rsync -r -d -x '(^|/)\.git/' ${{ env.SYNC_DIR }} gs://${{ env.BUCKET }}/
-
-
-        run: gsutil -m rsync -r -d ./${{ env.build_dir }} gs://${{ env.BUCKET }}/
+        run: gsutil -m rsync -r -d -x '(^|/)\.git/|(^|/)node_modules/' ${{ env.SYNC_DIR }} gs://${{ env.BUCKET }}/
 
       - name: Set Cache-Control (optional)
         run: gsutil -m setmeta -h "Cache-Control:public, max-age=300" gs://${{ env.BUCKET }}/** || true


### PR DESCRIPTION
## Summary
- setup Node.js 18 with npm cache
- add npm install and build steps before deployment
- simplify and clean up GCS sync step
- avoid uploading node_modules to GCS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: esbuild: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6897757ddd3483209b5968cb7e7a1348